### PR TITLE
Allow sent packets to appear in echoed CAN traffic

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -270,8 +270,8 @@ void searchForDevices() {
 
 		// Create rx listener
 		newDevice.device->addMessageCallback(icsneo::CANMessageCallback([serial](std::shared_ptr<icsneo::Message> message) {
-			if(message->transmitted)
-				return;
+			//if(message->transmitted)
+			//	return;
 			auto canMessage = std::static_pointer_cast<icsneo::CANMessage>(message);
 			const OpenDevice* openDevice = nullptr;
 			std::lock_guard<std::mutex> lg(openDevicesMutex);


### PR DESCRIPTION
Comment out lines that prevent sent CAN traffic from being echoed to the console